### PR TITLE
delete route fixes

### DIFF
--- a/lib/mux/middleware/simplify_response.ex
+++ b/lib/mux/middleware/simplify_response.ex
@@ -5,10 +5,13 @@ defmodule Mux.Middleware.SimplifyResponse do
   def call(env, next, _options) do
     with {:ok, resp} <- Tesla.run(env, next),
          %{status: status} when status >= 200 and status < 300 <- resp do
-      {:ok, resp.body["data"], resp}
+      {:ok, get_response_contents(resp.body), resp}
     else
       %{body: %{"error" => %{"type" => type, "messages" => messages}}} -> {:error, type, messages}
       err -> raise Mux.Exception, err
     end
   end
+
+  defp get_response_contents(body) when is_map(body), do: body["data"]
+  defp get_response_contents(body), do: body
 end

--- a/lib/mux/video/assets.ex
+++ b/lib/mux/video/assets.ex
@@ -62,7 +62,7 @@ defmodule Mux.Video.Assets do
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {status, nil, _env} = Mux.Video.Assets.delete(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc")
+      iex> {status, "", _env} = Mux.Video.Assets.delete(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc")
       iex> status
       :ok
 

--- a/lib/mux/video/playback_ids.ex
+++ b/lib/mux/video/playback_ids.ex
@@ -48,9 +48,9 @@ defmodule Mux.Video.PlaybackIds do
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {:ok, playback_id, _env} = Mux.Video.PlaybackIds.delete(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", "FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE")
-      iex> playback_id
-      nil
+      iex> {status, "", _env} = Mux.Video.PlaybackIds.delete(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", "FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE")
+      iex> status
+      :ok
 
   """
   def delete(client, asset_id, playback_id) do

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Mux.MixProject do
   def project do
     [
       app: :mux,
-      version: "1.0.0-beta.0",
+      version: "1.0.0-beta.1",
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/mux/video/assets_test.exs
+++ b/test/mux/video/assets_test.exs
@@ -30,7 +30,7 @@ defmodule Mux.Video.AssetsTest do
           "data" => Mux.Fixtures.asset(:create)
         }}
       %{method: :delete} ->
-        %Tesla.Env{status: 204, body: %{}}
+        %Tesla.Env{status: 204, body: ""}
     end
 
     {:ok, %{client: client}}

--- a/test/mux/video/playback_ids_test.exs
+++ b/test/mux/video/playback_ids_test.exs
@@ -18,7 +18,7 @@ defmodule Mux.PlaybackIdsTest do
           "data" => Mux.Fixtures.playback_id(),
         }}
       %{method: :delete, url: @base_url <> "/FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE"} ->
-        %Tesla.Env{status: 204, body: %{}}
+        %Tesla.Env{status: 204, body: ""}
     end
 
     {:ok, %{client: client}}


### PR DESCRIPTION
Right now, the routes that delete resources look for a key within the response, but the response is empty. Avoid this error being raised in the case of a successful delete by looking in the appropriate location, and fix the test setup.