### PR TITLE
Update readme "Installation" to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add `mux` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:mux, "~> 1.1.0"}
+    {:mux, "~> 1.2.0"}
   ]
 end
 ```


### PR DESCRIPTION
Livestreams doesn't exist in 1.1, after following the installation instructions I was seeing this error when trying to use LiveStreams module

> (UndefinedFunctionError) function Mux.Video.LiveStreams.create/2 is undefined (module Mux.Video.LiveStreams is not available)