### PR TITLE
add Mux.Video.Tracks (create and delete methods)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add `mux` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:mux, "~> 1.5.0"}
+    {:mux, "~> 1.6.0"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -112,3 +112,15 @@ Mux.Webhooks.verify_header(raw_body, signature_header, secret)
 
 You will most likely have to store the raw body before it gets parsed and then extract it later and
 pass it into `Mux.Webhooks.verify_header/3`
+
+---
+
+## Publishing new versions
+
+1. Update version in mix.exs
+1. Update version in README
+1. Commit and open a PR
+1. After code is merged, tag master ex: `git tag v1.6.0` and `git push --tags`
+1. run `mix build`
+1. run `mix publish`
+

--- a/lib/mux/support/fixtures.ex
+++ b/lib/mux/support/fixtures.ex
@@ -106,6 +106,18 @@ defmodule Mux.Fixtures do
     }
   end
 
+  def track do
+    %{
+      type: "text",
+      text_type: "subtitles",
+      status: "preparing",
+      passthrough: "English",
+      name: "English",
+      language_code: "en",
+      id: "2"
+    }
+  end
+
   def simulcast_target do
     %{
       id: "vuOfW021mz5QA500wYEQ9SeUYvuYnpFz011mqSvski5T8claN02JN9ve2g",

--- a/lib/mux/video/tracks.ex
+++ b/lib/mux/video/tracks.ex
@@ -1,0 +1,43 @@
+defmodule Mux.Video.Tracks do
+  @moduledoc """
+  This module provides functions around managing tracks in Mux Video. Tracks are
+  used for subtitles/captions. [API Documentation](https://docs.mux.com/reference#create-a-subtitle-text-track).
+  """
+  alias Mux.{Base, Fixtures}
+
+  @doc """
+  Create a new asset track. [API Documentation](https://docs.mux.com/reference#create-a-subtitle-text-track)
+
+  Returns `{:ok, track, raw_env}`.
+
+  ## Examples
+
+      iex> client = Mux.Base.new("my_token_id", "my_token_secret")
+      iex> {:ok, track, _env} = Mux.Video.Tracks.create(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", %{url: "https://example.com/myVideo_en.srt", type: "text", text_type: "subtitles", language_code: "en" })
+      iex> track
+      #{inspect(Fixtures.track())}
+
+  """
+  def create(client, asset_id, params) do
+    Base.post(client, build_base_path(asset_id), params)
+  end
+
+  @doc """
+  Delete an asset track. [API Documentation](https://docs.mux.com/reference#delete-a-subtitle-text-track)
+
+  Returns `{:ok, nil, raw_env}`.
+
+  ## Examples
+
+      iex> client = Mux.Base.new("my_token_id", "my_token_secret")
+      iex> {status, "", _env} = Mux.Video.Tracks.delete(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", "FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE")
+      iex> status
+      :ok
+
+  """
+  def delete(client, asset_id, track_id) do
+    Base.delete(client, build_base_path(asset_id) <> "/" <> track_id)
+  end
+
+  defp build_base_path(asset_id), do: "/video/v1/assets/#{asset_id}/tracks"
+end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Mux.MixProject do
   def project do
     [
       app: :mux,
-      version: "1.5.0",
+      version: "1.6.0",
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/mux/video/tracks_test.exs
+++ b/test/mux/video/tracks_test.exs
@@ -1,0 +1,34 @@
+defmodule Mux.TracksTest do
+  use ExUnit.Case
+  import Tesla.Mock
+  doctest Mux.Video.Tracks
+
+  @base_url "https://api.mux.com/video/v1/assets/00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc/tracks"
+
+  setup do
+    client = Mux.Base.new("token_id", "token_secret", base_url: @base_url)
+
+    mock(fn
+      %{method: :post, url: @base_url} ->
+        %Tesla.Env{
+          status: 201,
+          body: %{
+            "data" => Mux.Fixtures.track()
+          }
+        }
+
+      %{method: :get, url: @base_url <> "/FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE"} ->
+        %Tesla.Env{
+          status: 200,
+          body: %{
+            "data" => Mux.Fixtures.track()
+          }
+        }
+
+      %{method: :delete, url: @base_url <> "/FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE"} ->
+        %Tesla.Env{status: 204, body: ""}
+    end)
+
+    {:ok, %{client: client}}
+  end
+end


### PR DESCRIPTION
I noticed in Node we do things like:

  * `Video.Assets.createPlaybackId`, and now `Video.Assets.createTrack`

But in elixir, PlaybackIds is it's own namespace:

  * `Mux.Video.PlaybackIds.create`

I followed suit and matched the pattern here, so we now have `Mux.Video.Tracks.create`.

I think it makes sense to match the pattern that is in the library, but I wanted to point out that we have a divergence here of weather to make sub-resources their own namespace, or to add them as methods on the parent resource

TODO

- [x] QA
- [x] bump to 1.6.0
- [x] document release process