### PR TITLE
remove mix build step, because it's not a thing for our library

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,5 @@ pass it into `Mux.Webhooks.verify_header/3`
 1. Update version in README
 1. Commit and open a PR
 1. After code is merged, tag master ex: `git tag v1.6.0` and `git push --tags`
-1. run `mix build`
 1. run `mix publish`
 


### PR DESCRIPTION
I added these steps in #14, but this step is not something we need