### PR TITLE
Add PlaybackIds API functionality

### DIFF
--- a/lib/mux/video/assets.ex
+++ b/lib/mux/video/assets.ex
@@ -4,7 +4,7 @@ defmodule Mux.Video.Assets do
   """
   alias Mux.{Base, Fixtures}
 
-  @path "/video/v1"
+  @path "/video/v1/assets"
 
   @doc """
   Create a new asset.
@@ -21,7 +21,7 @@ defmodule Mux.Video.Assets do
 
   """
   def create(client, params) do
-    Base.post(client, @path <> "/assets", params)
+    Base.post(client, @path, params)
   end
 
   @doc """
@@ -37,7 +37,7 @@ defmodule Mux.Video.Assets do
       #{inspect([Fixtures.asset(), Fixtures.asset()])}
 
   """
-  def list(client, params \\ []), do: Base.get(client, @path <> "/assets", query: params)
+  def list(client, params \\ []), do: Base.get(client, @path, query: params)
 
   @doc """
   Retrieve an asset by ID.
@@ -53,7 +53,7 @@ defmodule Mux.Video.Assets do
 
   """
   def get(client, asset_id, options \\ []) do
-    Base.get(client, @path <> "/assets/" <> asset_id, query: options)
+    Base.get(client, "#{@path}/#{asset_id}", query: options)
   end
 
   @doc """
@@ -70,7 +70,7 @@ defmodule Mux.Video.Assets do
 
   """
   def delete(client, asset_id, params \\ []) do
-    Base.delete(client, @path <> "/assets/" <> asset_id, query: params)
+    Base.delete(client, "#{@path}/#{asset_id}", query: params)
   end
 
   @doc """
@@ -87,7 +87,7 @@ defmodule Mux.Video.Assets do
 
   """
   def input_info(client, asset_id, params \\ []) do
-    Base.get(client, @path <> "/assets/" <> asset_id <> "/input-info", query: params)
+    Base.get(client, "#{@path}/#{asset_id}/input-info", query: params)
   end
 
   @doc """
@@ -104,7 +104,7 @@ defmodule Mux.Video.Assets do
 
   """
   def update_mp4_support(client, asset_id, params) do
-    Base.put(client, @path <> "/assets/" <> asset_id <> "/mp4-support", params)
+    Base.put(client, "#{@path}/#{asset_id}/mp4-support", params)
   end
 
   @doc """
@@ -121,6 +121,57 @@ defmodule Mux.Video.Assets do
 
   """
   def update_master_access(client, asset_id, params) do
-    Base.put(client, @path <> "/assets/" <> asset_id <> "/master-access", params)
+    Base.put(client, "#{@path}/#{asset_id}/master-access", params)
+  end
+
+    @doc """
+  Create a new playback ID.
+
+  Returns `{:ok, playback_id, raw_env}`.
+
+  ## Examples
+
+      iex> client = Mux.Base.new("my_token_id", "my_token_secret")
+      iex> {:ok, playback_id, _env} = Mux.Video.Assets.create_playback_id(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", %{policy: "public"})
+      iex> playback_id
+      #{inspect(Fixtures.playback_id())}
+
+  """
+  def create_playback_id(client, asset_id, params) do
+    Base.post(client, "#{@path}/#{asset_id}/playback-ids", params)
+  end
+
+  @doc """
+  Retrieve a playback ID by ID.
+
+  Returns `{:ok, playback_id, raw_env}`.
+
+  ## Examples
+
+      iex> client = Mux.Base.new("my_token_id", "my_token_secret")
+      iex> {:ok, playback_id, _env} = Mux.Video.Assets.get_playback_id(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", "FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE")
+      iex> playback_id
+      #{inspect(Fixtures.playback_id())}
+
+  """
+  def get_playback_id(client, asset_id, playback_id) do
+    Base.get(client, "#{@path}/#{asset_id}/playback-ids/#{playback_id}")
+  end
+
+  @doc """
+  Delete a playback ID.
+
+  Returns `{:ok, nil, raw_env}`.
+
+  ## Examples
+
+      iex> client = Mux.Base.new("my_token_id", "my_token_secret")
+      iex> {status, "", _env} = Mux.Video.Assets.delete_playback_id(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", "FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE")
+      iex> status
+      :ok
+
+  """
+  def delete_playback_id(client, asset_id, playback_id) do
+    Base.delete(client, "#{@path}/#{asset_id}/playback-ids/#{playback_id}")
   end
 end

--- a/lib/mux/video/playback_ids.ex
+++ b/lib/mux/video/playback_ids.ex
@@ -2,60 +2,27 @@ defmodule Mux.Video.PlaybackIds do
   @moduledoc """
   This module provides functions around managing Playback IDs in Mux Video. Playback IDs are the
   public identifier for streaming a piece of content and can include policies such as `signed` or
-  `public`. [API Documentation](https://docs.mux.com/v1/reference#playback-ids).
+  `public`. [API Documentation](https://docs.mux.com/api-reference/video#tag/playback-id).
   """
   alias Mux.{Base, Fixtures}
 
-  @doc """
-  Create a new playback ID.
+  @path "/video/v1/playback-ids"
 
-  Returns `{:ok, playback_id, raw_env}`.
+  @doc """
+  Retrieve a asset or live stream identifier by Playback ID.
+
+  Returns `{:ok, identifier, raw_env}`.
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {:ok, playback_id, _env} = Mux.Video.PlaybackIds.create(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", %{policy: "public"})
-      iex> playback_id
-      #{inspect(Fixtures.playback_id())}
+      iex> {:ok, identifier, _env} = Mux.Video.PlaybackIds.get(client, "FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE")
+      iex> identifier
+      #{inspect(Fixtures.identifier())}
 
   """
-  def create(client, asset_id, params) do
-    Base.post(client, build_base_path(asset_id), params)
+  def get(client, playback_id) do
+    Base.get(client, "#{@path}/#{playback_id}")
   end
 
-  @doc """
-  Retrieve a playback ID by ID.
-
-  Returns `{:ok, playback_id, raw_env}`.
-
-  ## Examples
-
-      iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {:ok, playback_id, _env} = Mux.Video.PlaybackIds.get(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", "FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE")
-      iex> playback_id
-      #{inspect(Fixtures.playback_id())}
-
-  """
-  def get(client, asset_id, playback_id) do
-    Base.get(client, build_base_path(asset_id) <> "/" <> playback_id)
-  end
-
-  @doc """
-  Delete a playback ID.
-
-  Returns `{:ok, nil, raw_env}`.
-
-  ## Examples
-
-      iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {status, "", _env} = Mux.Video.PlaybackIds.delete(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", "FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE")
-      iex> status
-      :ok
-
-  """
-  def delete(client, asset_id, playback_id) do
-    Base.delete(client, build_base_path(asset_id) <> "/" <> playback_id)
-  end
-
-  defp build_base_path(asset_id), do: "/video/v1/assets/#{asset_id}/playback-ids"
 end

--- a/test/mux/video/assets_test.exs
+++ b/test/mux/video/assets_test.exs
@@ -70,6 +70,25 @@ defmodule Mux.Video.AssetsTest do
           }
         }
 
+      %{method: :post, url: @base_url <> "/video/v1/assets/00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc/playback-ids"} ->
+        %Tesla.Env{
+          status: 201,
+          body: %{
+            "data" => Mux.Fixtures.asset()
+          }
+        }
+
+      %{method: :get, url: @base_url <> "video/v1/assets/00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc/playback-ids/FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE"} ->
+        %Tesla.Env{
+          status: 200,
+          body: %{
+            "data" => Mux.Fixtures.asset()
+          }
+        }
+
+      %{method: :delete, url: @base_url <> "video/v1/assets/00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc/playback-ids/FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE"} ->
+        %Tesla.Env{status: 204, body: ""}
+
       %{method: :delete} ->
         %Tesla.Env{status: 204, body: ""}
     end)

--- a/test/mux/video/playback_ids_test.exs
+++ b/test/mux/video/playback_ids_test.exs
@@ -1,34 +1,46 @@
-defmodule Mux.PlaybackIdsTest do
-  use ExUnit.Case
-  import Tesla.Mock
-  doctest Mux.Video.PlaybackIds
-
-  @base_url "https://api.mux.com/video/v1/assets/00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc/playback-ids"
-
-  setup do
-    client = Mux.Base.new("token_id", "token_secret", base_url: @base_url)
-
-    mock(fn
-      %{method: :post, url: @base_url} ->
-        %Tesla.Env{
-          status: 201,
-          body: %{
-            "data" => Mux.Fixtures.playback_id()
+defmodule Mux.Video.PlaybackIdsTest do
+    use ExUnit.Case
+    import Tesla.Mock
+    alias Mux.Video.PlaybackIds
+    doctest Mux.Video.PlaybackIds
+  
+    @base_url "https://api.mux.com/video/v1/playback-ids"
+  
+    setup do
+      client = Mux.Base.new("token_id", "token_secret", base_url: @base_url)
+  
+      mock(fn
+        %{method: :get, url: @base_url <> "/FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE"} ->
+          %Tesla.Env{
+            status: 200,
+            body: %{
+              "data" => Mux.Fixtures.playback_id()
+            }
           }
-        }
+      end)
+  
+      {:ok, %{client: client}}
+    end
 
-      %{method: :get, url: @base_url <> "/FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE"} ->
-        %Tesla.Env{
-          status: 200,
-          body: %{
-            "data" => Mux.Fixtures.playback_id()
-          }
-        }
-
-      %{method: :delete, url: @base_url <> "/FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE"} ->
-        %Tesla.Env{status: 204, body: ""}
-    end)
-
-    {:ok, %{client: client}}
+    describe "get/2" do
+      setup do
+        mock(fn
+          %{method: :get, url: @base_url <> "/FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE"} ->
+            %Tesla.Env{
+              status: 200,
+              body: %{
+                "data" => Mux.Fixtures.playback_id()
+              }
+            }
+        end)
+  
+        :ok
+      end
+  
+      test "gets an asset by playback ID", %{client: client} do
+        assert {:ok, %{"id" => "FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE"}, %Tesla.Env{}} =
+                 Assets.get(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc")
+      end
+    end
   end
-end
+  


### PR DESCRIPTION
This PR adds a true module for the 'playback-ids' route and reorganizes the old PlaybackIds module to the Asset module because its still under the 'asset' and 'live-stream' route. More info here: https://mux.slack.com/archives/C0141248U4T/p1617315415246300?thread_ts=1617308920.205800&cid=C0141248U4T