### PR TITLE
Add `playback-ids` route

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add `mux` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:mux, "~> 1.9.0"}
+    {:mux, "~> 2.0.0"}
   ]
 end
 ```

--- a/lib/mux/support/fixtures.ex
+++ b/lib/mux/support/fixtures.ex
@@ -73,6 +73,17 @@ defmodule Mux.Fixtures do
     }
   end
 
+  def identifier do
+    %{
+      "policy" => "public",
+      "object" => %{
+        "type" => "live_stream",
+        "id" => "ZXs9U1Wqr3C4GBVCOYRQOA00lLtijnVhehJIb8tlDzL00"
+      },
+      "id" => "7IxC7stYLro5Z4nEs97J02OkLEKFME6mvhnuRJybhRKU"
+    }
+  end
+
   def input_info() do
     %{
       "file" => %{

--- a/lib/mux/support/fixtures.ex
+++ b/lib/mux/support/fixtures.ex
@@ -73,7 +73,7 @@ defmodule Mux.Fixtures do
     }
   end
 
-  def identifier do
+  def playback_id_full do
     %{
       "policy" => "public",
       "object" => %{

--- a/lib/mux/video/assets.ex
+++ b/lib/mux/video/assets.ex
@@ -4,7 +4,7 @@ defmodule Mux.Video.Assets do
   """
   alias Mux.{Base, Fixtures}
 
-  @path "/video/v1"
+  @path "/video/v1/assets"
 
   @doc """
   Create a new asset.
@@ -21,7 +21,7 @@ defmodule Mux.Video.Assets do
 
   """
   def create(client, params) do
-    Base.post(client, @path <> "/assets", params)
+    Base.post(client, @path, params)
   end
 
   @doc """
@@ -37,7 +37,7 @@ defmodule Mux.Video.Assets do
       #{inspect([Fixtures.asset(), Fixtures.asset()])}
 
   """
-  def list(client, params \\ []), do: Base.get(client, @path <> "/assets", query: params)
+  def list(client, params \\ []), do: Base.get(client, @path, query: params)
 
   @doc """
   Retrieve an asset by ID.
@@ -53,7 +53,7 @@ defmodule Mux.Video.Assets do
 
   """
   def get(client, asset_id, options \\ []) do
-    Base.get(client, @path <> "/assets/" <> asset_id, query: options)
+    Base.get(client, "#{@path}/#{asset_id}", query: options)
   end
 
   @doc """
@@ -70,7 +70,7 @@ defmodule Mux.Video.Assets do
 
   """
   def delete(client, asset_id, params \\ []) do
-    Base.delete(client, @path <> "/assets/" <> asset_id, query: params)
+    Base.delete(client, "#{@path}/#{asset_id}", query: params)
   end
 
   @doc """
@@ -87,7 +87,7 @@ defmodule Mux.Video.Assets do
 
   """
   def input_info(client, asset_id, params \\ []) do
-    Base.get(client, @path <> "/assets/" <> asset_id <> "/input-info", query: params)
+    Base.get(client, "#{@path}/#{asset_id}/input-info", query: params)
   end
 
   @doc """
@@ -104,7 +104,7 @@ defmodule Mux.Video.Assets do
 
   """
   def update_mp4_support(client, asset_id, params) do
-    Base.put(client, @path <> "/assets/" <> asset_id <> "/mp4-support", params)
+    Base.put(client, "#{@path}/#{asset_id}/mp4-support", params)
   end
 
   @doc """
@@ -121,6 +121,57 @@ defmodule Mux.Video.Assets do
 
   """
   def update_master_access(client, asset_id, params) do
-    Base.put(client, @path <> "/assets/" <> asset_id <> "/master-access", params)
+    Base.put(client, "#{@path}/#{asset_id}/master-access", params)
+  end
+
+    @doc """
+  Create a new playback ID.
+
+  Returns `{:ok, playback_id, raw_env}`.
+
+  ## Examples
+
+      iex> client = Mux.Base.new("my_token_id", "my_token_secret")
+      iex> {:ok, playback_id, _env} = Mux.Video.Assets.create_playback_id(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", %{policy: "public"})
+      iex> playback_id
+      #{inspect(Fixtures.playback_id())}
+
+  """
+  def create_playback_id(client, asset_id, params) do
+    Base.post(client, "#{@path}/#{asset_id}/playback-ids", params)
+  end
+
+  @doc """
+  Retrieve a playback ID by ID.
+
+  Returns `{:ok, playback_id, raw_env}`.
+
+  ## Examples
+
+      iex> client = Mux.Base.new("my_token_id", "my_token_secret")
+      iex> {:ok, playback_id, _env} = Mux.Video.Assets.get_playback_id(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", "FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE")
+      iex> playback_id
+      #{inspect(Fixtures.playback_id())}
+
+  """
+  def get_playback_id(client, asset_id, playback_id) do
+    Base.get(client, "#{@path}/#{asset_id}/playback-ids/#{playback_id}")
+  end
+
+  @doc """
+  Delete a playback ID.
+
+  Returns `{:ok, nil, raw_env}`.
+
+  ## Examples
+
+      iex> client = Mux.Base.new("my_token_id", "my_token_secret")
+      iex> {status, "", _env} = Mux.Video.Assets.delete_playback_id(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", "FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE")
+      iex> status
+      :ok
+
+  """
+  def delete_playback_id(client, asset_id, playback_id) do
+    Base.delete(client, "#{@path}/#{asset_id}/playback-ids/#{playback_id}")
   end
 end

--- a/lib/mux/video/assets.ex
+++ b/lib/mux/video/assets.ex
@@ -127,14 +127,14 @@ defmodule Mux.Video.Assets do
   @doc """
   Create a new playback ID.
 
-  Returns `{:ok, playback_id, %Telsa.Client{}}`.
+  Returns `{:ok, playback_id, %Telsa.Env{}}`.
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
       iex> {:ok, playback_id, _env} = Mux.Video.Assets.create_playback_id(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", %{policy: "public"})
       iex> playback_id
-      #{inspect(Fixtures.asset(:create))}
+      #{inspect(Fixtures.playback_id)}
 
   """
   def create_playback_id(client, asset_id, params) do
@@ -142,16 +142,16 @@ defmodule Mux.Video.Assets do
   end
 
   @doc """
-  Create a new playback ID.
+  Retrieve a playback ID.
 
-  Returns `{:ok, playback_id, %Telsa.Client{}}`.
+  Returns `{:ok, playback_id, %Telsa.Env{}}`.
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {:ok, playback_id, _env} = Mux.Video.Assets.create_playback_id(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", %{policy: "public"})
+      iex> {:ok, playback_id, _env} = Mux.Video.Assets.get_playback_id(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", "FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE")
       iex> playback_id
-      #{inspect(Fixtures.asset(:create))}
+      #{inspect(Fixtures.playback_id)}
 
   """
   def get_playback_id(client, asset_id, playback_id) do

--- a/lib/mux/video/assets.ex
+++ b/lib/mux/video/assets.ex
@@ -124,17 +124,17 @@ defmodule Mux.Video.Assets do
     Base.put(client, "#{@path}/#{asset_id}/master-access", params)
   end
 
-    @doc """
+  @doc """
   Create a new playback ID.
 
-  Returns `{:ok, playback_id, raw_env}`.
+  Returns `{:ok, playback_id, %Telsa.Client{}}`.
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
       iex> {:ok, playback_id, _env} = Mux.Video.Assets.create_playback_id(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", %{policy: "public"})
       iex> playback_id
-      #{inspect(Fixtures.playback_id())}
+      #{inspect(Fixtures.asset(:create))}
 
   """
   def create_playback_id(client, asset_id, params) do
@@ -142,16 +142,16 @@ defmodule Mux.Video.Assets do
   end
 
   @doc """
-  Retrieve a playback ID by ID.
+  Create a new playback ID.
 
-  Returns `{:ok, playback_id, raw_env}`.
+  Returns `{:ok, playback_id, %Telsa.Client{}}`.
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {:ok, playback_id, _env} = Mux.Video.Assets.get_playback_id(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", "FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE")
+      iex> {:ok, playback_id, _env} = Mux.Video.Assets.create_playback_id(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", %{policy: "public"})
       iex> playback_id
-      #{inspect(Fixtures.playback_id())}
+      #{inspect(Fixtures.asset(:create))}
 
   """
   def get_playback_id(client, asset_id, playback_id) do
@@ -161,7 +161,7 @@ defmodule Mux.Video.Assets do
   @doc """
   Delete a playback ID.
 
-  Returns `{:ok, nil, raw_env}`.
+  Returns `{:ok, nil, %Telsa.Env{}}`.
 
   ## Examples
 

--- a/lib/mux/video/playback_ids.ex
+++ b/lib/mux/video/playback_ids.ex
@@ -2,60 +2,27 @@ defmodule Mux.Video.PlaybackIds do
   @moduledoc """
   This module provides functions around managing Playback IDs in Mux Video. Playback IDs are the
   public identifier for streaming a piece of content and can include policies such as `signed` or
-  `public`. [API Documentation](https://docs.mux.com/v1/reference#playback-ids).
+  `public`. [API Documentation](https://docs.mux.com/api-reference/video#tag/playback-id).
   """
   alias Mux.{Base, Fixtures}
 
-  @doc """
-  Create a new playback ID.
+  @path "/video/v1/playback-ids"
 
-  Returns `{:ok, playback_id, raw_env}`.
+  @doc """
+  Retrieve a asset or live stream identifier by Playback ID.
+
+  Returns `{:ok, identifier, raw_env}`.
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {:ok, playback_id, _env} = Mux.Video.PlaybackIds.create(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", %{policy: "public"})
-      iex> playback_id
-      #{inspect(Fixtures.playback_id())}
+      iex> {:ok, identifier, _env} = Mux.Video.PlaybackIds.get(client, "FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE")
+      iex> identifier
+      #{inspect(Fixtures.identifier())}
 
   """
-  def create(client, asset_id, params) do
-    Base.post(client, build_base_path(asset_id), params)
+  def get(client, playback_id) do
+    Base.get(client, "#{@path}/#{playback_id}")
   end
 
-  @doc """
-  Retrieve a playback ID by ID.
-
-  Returns `{:ok, playback_id, raw_env}`.
-
-  ## Examples
-
-      iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {:ok, playback_id, _env} = Mux.Video.PlaybackIds.get(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", "FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE")
-      iex> playback_id
-      #{inspect(Fixtures.playback_id())}
-
-  """
-  def get(client, asset_id, playback_id) do
-    Base.get(client, build_base_path(asset_id) <> "/" <> playback_id)
-  end
-
-  @doc """
-  Delete a playback ID.
-
-  Returns `{:ok, nil, raw_env}`.
-
-  ## Examples
-
-      iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {status, "", _env} = Mux.Video.PlaybackIds.delete(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", "FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE")
-      iex> status
-      :ok
-
-  """
-  def delete(client, asset_id, playback_id) do
-    Base.delete(client, build_base_path(asset_id) <> "/" <> playback_id)
-  end
-
-  defp build_base_path(asset_id), do: "/video/v1/assets/#{asset_id}/playback-ids"
 end

--- a/lib/mux/video/playback_ids.ex
+++ b/lib/mux/video/playback_ids.ex
@@ -11,14 +11,14 @@ defmodule Mux.Video.PlaybackIds do
   @doc """
   Retrieve a asset or live stream identifier by Playback ID.
 
-  Returns `{:ok, identifier, raw_env}`.
+  Returns `{:ok, playback_id_full, raw_env}`.
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {:ok, identifier, _env} = Mux.Video.PlaybackIds.get(client, "FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE")
-      iex> identifier
-      #{inspect(Fixtures.identifier())}
+      iex> {:ok, playback_id_full, _env} = Mux.Video.PlaybackIds.get(client, "FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE")
+      iex> playback_id_full
+      #{inspect(Fixtures.playback_id_full())}
 
   """
   def get(client, playback_id) do

--- a/lib/mux/video/playback_ids.ex
+++ b/lib/mux/video/playback_ids.ex
@@ -24,5 +24,4 @@ defmodule Mux.Video.PlaybackIds do
   def get(client, playback_id) do
     Base.get(client, "#{@path}/#{playback_id}")
   end
-
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Mux.MixProject do
 
   @github_url "https://github.com/muxinc/mux-elixir"
 
-  @version "1.9.0"
+  @version "2.0.0"
 
   def project do
     [

--- a/test/mux/video/assets_test.exs
+++ b/test/mux/video/assets_test.exs
@@ -40,7 +40,7 @@ defmodule Mux.Video.AssetsTest do
           }
         }
 
-      %{method: :post} ->
+      %{method: :post, url: @base_url <> "/video/v1/assets"} ->
         %Tesla.Env{
           status: 201,
           body: %{
@@ -85,7 +85,7 @@ defmodule Mux.Video.AssetsTest do
         method: :get,
         url:
           @base_url <>
-              "video/v1/assets/00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc/playback-ids/FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE"
+              "/video/v1/assets/00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc/playback-ids/FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE"
       } ->
         %Tesla.Env{
           status: 200,
@@ -98,7 +98,7 @@ defmodule Mux.Video.AssetsTest do
         method: :delete,
         url:
           @base_url <>
-              "video/v1/assets/00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc/playback-ids/FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE"
+              "/video/v1/assets/00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc/playback-ids/FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE"
       } ->
         %Tesla.Env{status: 204, body: ""}
 

--- a/test/mux/video/assets_test.exs
+++ b/test/mux/video/assets_test.exs
@@ -70,6 +70,25 @@ defmodule Mux.Video.AssetsTest do
           }
         }
 
+      %{method: :post, url: @base_url <> "/video/v1/assets/00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc/playback-ids"} ->
+        %Tesla.Env{
+          status: 201,
+          body: %{
+            "data" => Mux.Fixtures.asset()
+          }
+        }
+
+      %{method: :get, url: @base_url <> "video/v1/assets/00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc/playback-ids/FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE"} ->
+        %Tesla.Env{
+          status: 200,
+          body: %{
+            "data" => Mux.Fixtures.asset()
+          }
+        }
+
+      %{method: :delete, url: @base_url <> "video/v1/assets/00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc/playback-ids/FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE"} ->
+        %Tesla.Env{status: 204, body: ""}
+
       %{method: :delete} ->
         %Tesla.Env{status: 204, body: ""}
     end)

--- a/test/mux/video/assets_test.exs
+++ b/test/mux/video/assets_test.exs
@@ -77,7 +77,7 @@ defmodule Mux.Video.AssetsTest do
         %Tesla.Env{
           status: 201,
           body: %{
-            "data" => Mux.Fixtures.asset(:create)
+            "data" => Mux.Fixtures.playback_id()
           }
         }
 

--- a/test/mux/video/assets_test.exs
+++ b/test/mux/video/assets_test.exs
@@ -70,23 +70,36 @@ defmodule Mux.Video.AssetsTest do
           }
         }
 
-      %{method: :post, url: @base_url <> "/video/v1/assets/00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc/playback-ids"} ->
+      %{
+        method: :post,
+        url: @base_url <> "/video/v1/assets/00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc/playback-ids"
+      } ->
         %Tesla.Env{
           status: 201,
           body: %{
-            "data" => Mux.Fixtures.asset()
+            "data" => Mux.Fixtures.asset(:create)
           }
         }
 
-      %{method: :get, url: @base_url <> "video/v1/assets/00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc/playback-ids/FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE"} ->
+      %{
+        method: :get,
+        url:
+          @base_url <>
+              "video/v1/assets/00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc/playback-ids/FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE"
+      } ->
         %Tesla.Env{
           status: 200,
           body: %{
-            "data" => Mux.Fixtures.asset()
+            "data" => Mux.Fixtures.playback_id()
           }
         }
 
-      %{method: :delete, url: @base_url <> "video/v1/assets/00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc/playback-ids/FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE"} ->
+      %{
+        method: :delete,
+        url:
+          @base_url <>
+              "video/v1/assets/00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc/playback-ids/FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE"
+      } ->
         %Tesla.Env{status: 204, body: ""}
 
       %{method: :delete} ->

--- a/test/mux/video/live_streams_test.exs
+++ b/test/mux/video/live_streams_test.exs
@@ -102,7 +102,7 @@ defmodule Mux.Video.LiveStreamsTest do
             "data" => ""
           }
         }
-      
+
       %{method: :put, url: @base_url <> "/aA02skpHXoLrbQm49qIzAG6RtewFOcDEY/enable"} ->
         %Tesla.Env{
           status: 200,
@@ -110,8 +110,7 @@ defmodule Mux.Video.LiveStreamsTest do
             "data" => ""
           }
         }
-      
-      
+
       %{method: :put, url: @base_url <> "/aA02skpHXoLrbQm49qIzAG6RtewFOcDEY/disable"} ->
         %Tesla.Env{
           status: 200,

--- a/test/mux/video/playback_ids_test.exs
+++ b/test/mux/video/playback_ids_test.exs
@@ -1,34 +1,46 @@
-defmodule Mux.PlaybackIdsTest do
-  use ExUnit.Case
-  import Tesla.Mock
-  doctest Mux.Video.PlaybackIds
-
-  @base_url "https://api.mux.com/video/v1/assets/00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc/playback-ids"
-
-  setup do
-    client = Mux.Base.new("token_id", "token_secret", base_url: @base_url)
-
-    mock(fn
-      %{method: :post, url: @base_url} ->
-        %Tesla.Env{
-          status: 201,
-          body: %{
-            "data" => Mux.Fixtures.playback_id()
+defmodule Mux.Video.PlaybackIdsTest do
+    use ExUnit.Case
+    import Tesla.Mock
+    alias Mux.Video.PlaybackIds
+    doctest Mux.Video.PlaybackIds
+  
+    @base_url "https://api.mux.com/video/v1/playback-ids"
+  
+    setup do
+      client = Mux.Base.new("token_id", "token_secret", base_url: @base_url)
+  
+      mock(fn
+        %{method: :get, url: @base_url <> "/FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE"} ->
+          %Tesla.Env{
+            status: 200,
+            body: %{
+              "data" => Mux.Fixtures.playback_id()
+            }
           }
-        }
+      end)
+  
+      {:ok, %{client: client}}
+    end
 
-      %{method: :get, url: @base_url <> "/FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE"} ->
-        %Tesla.Env{
-          status: 200,
-          body: %{
-            "data" => Mux.Fixtures.playback_id()
-          }
-        }
-
-      %{method: :delete, url: @base_url <> "/FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE"} ->
-        %Tesla.Env{status: 204, body: ""}
-    end)
-
-    {:ok, %{client: client}}
+    describe "get/2" do
+      setup do
+        mock(fn
+          %{method: :get, url: @base_url <> "/FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE"} ->
+            %Tesla.Env{
+              status: 200,
+              body: %{
+                "data" => Mux.Fixtures.playback_id()
+              }
+            }
+        end)
+  
+        :ok
+      end
+  
+      test "gets an asset by playback ID", %{client: client} do
+        assert {:ok, %{"id" => "FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE"}, %Tesla.Env{}} =
+                 Assets.get(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc")
+      end
+    end
   end
-end
+  

--- a/test/mux/video/playback_ids_test.exs
+++ b/test/mux/video/playback_ids_test.exs
@@ -1,46 +1,23 @@
 defmodule Mux.Video.PlaybackIdsTest do
-    use ExUnit.Case
-    import Tesla.Mock
-    alias Mux.Video.PlaybackIds
-    doctest Mux.Video.PlaybackIds
-  
-    @base_url "https://api.mux.com/video/v1/playback-ids"
-  
-    setup do
-      client = Mux.Base.new("token_id", "token_secret", base_url: @base_url)
-  
-      mock(fn
-        %{method: :get, url: @base_url <> "/FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE"} ->
-          %Tesla.Env{
-            status: 200,
-            body: %{
-              "data" => Mux.Fixtures.playback_id()
-            }
-          }
-      end)
-  
-      {:ok, %{client: client}}
-    end
+  use ExUnit.Case
+  import Tesla.Mock
+  doctest Mux.Video.PlaybackIds
 
-    describe "get/2" do
-      setup do
-        mock(fn
-          %{method: :get, url: @base_url <> "/FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE"} ->
-            %Tesla.Env{
-              status: 200,
-              body: %{
-                "data" => Mux.Fixtures.playback_id()
-              }
-            }
-        end)
-  
-        :ok
-      end
-  
-      test "gets an asset by playback ID", %{client: client} do
-        assert {:ok, %{"id" => "FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE"}, %Tesla.Env{}} =
-                 Assets.get(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc")
-      end
-    end
+  @base_url "https://api.mux.com/video/v1/playback-ids"
+
+  setup do
+    client = Mux.Base.new("token_id", "token_secret", base_url: @base_url)
+
+    mock(fn
+      %{method: :get, url: @base_url <> "/FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE"} ->
+        %Tesla.Env{
+          status: 200,
+          body: %{
+            "data" => Mux.Fixtures.identifier()
+          }
+        }
+    end)
+
+    {:ok, %{client: client}}
   end
-  
+end

--- a/test/mux/video/playback_ids_test.exs
+++ b/test/mux/video/playback_ids_test.exs
@@ -13,7 +13,7 @@ defmodule Mux.Video.PlaybackIdsTest do
         %Tesla.Env{
           status: 200,
           body: %{
-            "data" => Mux.Fixtures.identifier()
+            "data" => Mux.Fixtures.playback_id_full()
           }
         }
     end)


### PR DESCRIPTION
This PR adds the new `playback-ids` route: https://docs.mux.com/api-reference/video#operation/get-asset-or-livestream-id as well as rearranges the Assets module to now include the handling of Assets' playback IDs which may break some things