### PR TITLE
Make middleware comply with the expected shape

### DIFF
--- a/lib/mux/data/errors.ex
+++ b/lib/mux/data/errors.ex
@@ -8,17 +8,17 @@ defmodule Mux.Data.Errors do
   @doc """
   Returns a list of playback errors along with details and statistics about them.
 
-  Returns `{:ok, errors, raw_env}`.
+  Returns `{:ok, raw_env | errors}`.
 
   ## Examples
 
       iex> client = Mux.client("my_token_id", "my_token_secret")
-      iex> {:ok, errors, _env} = Mux.Data.Errors.list(client)
+      iex> {:ok, %{clean_body: errors} = _env} = Mux.Data.Errors.list(client)
       iex> errors
       #{inspect(Fixtures.errors()["data"])}
 
       iex> client = Mux.client("my_token_id", "my_token_secret")
-      iex> {:ok, errors, _env} = Mux.Data.Errors.list(client, filters: ["operating_system:windows"], timeframe: ["24:hours"])
+      iex> {:ok, %{clean_body: errors} = _env} = Mux.Data.Errors.list(client, filters: ["operating_system:windows"], timeframe: ["24:hours"])
       iex> errors
       #{inspect(Fixtures.errors()["data"])}
 

--- a/lib/mux/data/exports.ex
+++ b/lib/mux/data/exports.ex
@@ -11,12 +11,12 @@ defmodule Mux.Data.Exports do
   @doc """
   Lists the available video view exports along with URLs to retrieve them.
 
-  Returns `{:ok, exports, raw_env}`.
+  Returns `{:ok, raw_env | exports}`.
 
   ## Examples
 
       iex> client = Mux.client("my_token_id", "my_token_secret")
-      iex> {:ok, exports, _env} = Mux.Data.Exports.list(client)
+      iex> {:ok, %{clean_body: exports} = _env} = Mux.Data.Exports.list(client)
       iex> exports
       #{inspect(Fixtures.exports()["data"])}
 

--- a/lib/mux/data/filters.ex
+++ b/lib/mux/data/filters.ex
@@ -13,7 +13,7 @@ defmodule Mux.Data.Filters do
   ## Examples
 
       iex> client = Mux.client("my_token_id", "my_token_secret")
-      iex> {:ok, filters, _env} = Mux.Data.Filters.list(client)
+      iex> {:ok, %{clean_body: filters} = _env} = Mux.Data.Filters.list(client)
       iex> filters
       #{inspect(Fixtures.filters()["data"])}
 
@@ -25,12 +25,12 @@ defmodule Mux.Data.Filters do
   @doc """
   Lists the values for a specific filter along with a total count of related views.
 
-  Returns `{:ok, filters, raw_env}`.
+  Returns `{:ok, raw_env | filters}`.
 
   ## Examples
 
       iex> client = Mux.client("my_token_id", "my_token_secret")
-      iex> {:ok, filters, _env} = Mux.Data.Filters.get(client, "browser")
+      iex> {:ok, %{clean_body: filters} = _env} = Mux.Data.Filters.get(client, "browser")
       iex> filters
       #{inspect(Fixtures.filters(:browser)["data"])}
 

--- a/lib/mux/data/incidents.ex
+++ b/lib/mux/data/incidents.ex
@@ -8,12 +8,12 @@ defmodule Mux.Data.Incidents do
   @doc """
   Lists all incidents.
 
-  Returns `{:ok, incidents, raw_env}`.
+  Returns `{:ok, raw_env | incidents}`.
 
   ## Examples
 
       iex> client = Mux.client("my_token_id", "my_token_secret")
-      iex> {:ok, incidents, _env} = Mux.Data.Incidents.list(client, status: 'open', severity: 'alert')
+      iex> {:ok, %{clean_body: incidents} = _env} = Mux.Data.Incidents.list(client, status: 'open', severity: 'alert')
       iex> incidents
       #{inspect(Fixtures.incidents()["data"])}
 
@@ -25,12 +25,12 @@ defmodule Mux.Data.Incidents do
   @doc """
   Lists details for a single incident.
 
-  Returns `{:ok, incident, raw_env}`.
+  Returns `{:ok, raw_env | incident}`.
 
   ## Examples
 
       iex> client = Mux.client("my_token_id", "my_token_secret")
-      iex> {:ok, incident, _env} = Mux.Data.Incidents.get(client, "ABCD1234")
+      iex> {:ok, %{clean_body: incident} = _env} = Mux.Data.Incidents.get(client, "ABCD1234")
       iex> incident
       #{inspect(Fixtures.incident()["data"])}
 
@@ -42,12 +42,12 @@ defmodule Mux.Data.Incidents do
   @doc """
   Lists all the incidents that seem related to a specific incident.
 
-  Returns `{:ok, incidents, raw_env}`.
+  Returns `{:ok, raw_env | incidents}`.
 
   ## Examples
 
       iex> client = Mux.client("my_token_id", "my_token_secret")
-      iex> {:ok, incidents, _env} = Mux.Data.Incidents.related(client, "ABCD1234", measurement: "median")
+      iex> {:ok, %{clean_body: incidents} = _env} = Mux.Data.Incidents.related(client, "ABCD1234", measurement: "median")
       iex> incidents
       #{inspect(Fixtures.related_incidents()["data"])}
 

--- a/lib/mux/data/metrics.ex
+++ b/lib/mux/data/metrics.ex
@@ -15,17 +15,17 @@ defmodule Mux.Data.Metrics do
   @doc """
   List the breakdown values for a specific metric.
 
-  Returns `{:ok, breakdowns, raw_env}`.
+  Returns `{:ok, raw_env | breakdowns}`.
 
   ## Examples
 
       iex> client = Mux.client("my_token_id", "my_token_secret")
-      iex> {:ok, breakdowns, _env} = Mux.Data.Metrics.breakdown(client, "video_startup_time", "browser")
+      iex> {:ok, %{clean_body: breakdowns} = _env} = Mux.Data.Metrics.breakdown(client, "video_startup_time", "browser")
       iex> breakdowns
       #{inspect(Fixtures.breakdown()["data"])}
 
       iex> client = Mux.client("my_token_id", "my_token_secret")
-      iex> {:ok, breakdowns, _env} = Mux.Data.Metrics.breakdown(client, "video_startup_time", "browser", measurement: "median", timeframe: ["6:hours"])
+      iex> {:ok, %{clean_body: breakdowns} = _env} = Mux.Data.Metrics.breakdown(client, "video_startup_time", "browser", measurement: "median", timeframe: ["6:hours"])
       iex> breakdowns
       #{inspect(Fixtures.breakdown()["data"])}
 
@@ -39,12 +39,12 @@ defmodule Mux.Data.Metrics do
   @doc """
   List all of the values across every breakdown for a specific breakdown value.
 
-  Returns `{:ok, comparisons, raw_env}`.
+  Returns `{:ok, raw_env | comparisons}`.
 
   ## Examples
 
       iex> client = Mux.client("my_token_id", "my_token_secret")
-      iex> {:ok, comparison, _env} = Mux.Data.Metrics.comparison(client, "browser", "Safari")
+      iex> {:ok, %{clean_body: comparison} = _env} = Mux.Data.Metrics.comparison(client, "browser", "Safari")
       iex> comparison
       #{inspect(Fixtures.comparison()["data"])}
 
@@ -58,12 +58,12 @@ defmodule Mux.Data.Metrics do
   Returns a list of insights for a metric. These are the worst performing values across all breakdowns
   sorted by how much they negatively impact a specific metric.
 
-  Returns `{:ok, insights, raw_env}`.
+  Returns `{:ok, raw_env | insights}`.
 
   ## Examples
 
       iex> client = Mux.client("my_token_id", "my_token_secret")
-      iex> {:ok, insights, _env} = Mux.Data.Metrics.insights(client, "video_startup_time")
+      iex> {:ok, %{clean_body: insights} = _env} = Mux.Data.Metrics.insights(client, "video_startup_time")
       iex> insights
       #{inspect(Fixtures.insights()["data"])}
 
@@ -76,12 +76,12 @@ defmodule Mux.Data.Metrics do
   Returns the overall value for a specific metric, as well as the total view count, watch time, and
   the Mux Global metric value for the metric.
 
-  Returns `{:ok, overall_values, raw_env}`.
+  Returns `{:ok, raw_env | overall_values}`.
 
   ## Examples
 
       iex> client = Mux.client("my_token_id", "my_token_secret")
-      iex> {:ok, insights, _env} = Mux.Data.Metrics.overall(client, "video_startup_time")
+      iex> {:ok, %{clean_body: insights} = _env} = Mux.Data.Metrics.overall(client, "video_startup_time")
       iex> insights
       #{inspect(Fixtures.overall()["data"])}
 
@@ -93,12 +93,12 @@ defmodule Mux.Data.Metrics do
   @doc """
   Returns time series data for a given metric.
 
-  Returns `{:ok, timeseries, raw_env}`.
+  Returns `{:ok, raw_env | timeseries}`.
 
   ## Examples
 
       iex> client = Mux.client("my_token_id", "my_token_secret")
-      iex> {:ok, timeseries, _env} = Mux.Data.Metrics.timeseries(client, "video_startup_time")
+      iex> {:ok, %{clean_body: timeseries} = _env} = Mux.Data.Metrics.timeseries(client, "video_startup_time")
       iex> timeseries
       #{inspect(Fixtures.timeseries()["data"])}
 

--- a/lib/mux/data/real_time.ex
+++ b/lib/mux/data/real_time.ex
@@ -14,12 +14,12 @@ defmodule Mux.Data.RealTime do
   @doc """
   List of available real-time dimensions
 
-  Returns `{:ok, dimensions, raw_env}`.
+  Returns `{:ok, raw_env | dimensions}`.
 
   ## Examples
 
       iex> client = Mux.client("my_token_id", "my_token_secret")
-      iex> {:ok, dimensions, _env} = Mux.Data.RealTime.dimensions(client)
+      iex> {:ok, %{clean_body: dimensions} = _env} = Mux.Data.RealTime.dimensions(client)
       iex> dimensions
       #{inspect(Fixtures.realtime_dimensions()["data"])}
 
@@ -31,12 +31,12 @@ defmodule Mux.Data.RealTime do
   @doc """
   List of available real-time metrics
 
-  Returns `{:ok, metrics, raw_env}`.
+  Returns `{:ok, raw_env | metrics}`.
 
   ## Examples
 
       iex> client = Mux.client("my_token_id", "my_token_secret")
-      iex> {:ok, metrics, _env} = Mux.Data.RealTime.metrics(client)
+      iex> {:ok, %{clean_body: metrics} = _env} = Mux.Data.RealTime.metrics(client)
       iex> metrics
       #{inspect(Fixtures.realtime_metrics()["data"])}
 
@@ -48,12 +48,12 @@ defmodule Mux.Data.RealTime do
   @doc """
   Get breakdown information for a specific dimension and metric along with the number of concurrent viewers and negative impact score.
 
-  Returns `{:ok, breakdown, raw_env}`.
+  Returns `{:ok, raw_env | breakdown}`.
 
   ## Examples
 
       iex> client = Mux.client("my_token_id", "my_token_secret")
-      iex> {:ok, breakdown, _env} = Mux.Data.RealTime.breakdown(client, "playback-failure-percentage", dimension: "country", timestamp: 1_547_853_000, filters: ["operating_system:windows"])
+      iex> {:ok, %{clean_body: breakdown} = _env} = Mux.Data.RealTime.breakdown(client, "playback-failure-percentage", dimension: "country", timestamp: 1_547_853_000, filters: ["operating_system:windows"])
       iex> breakdown
       #{inspect(Fixtures.realtime_breakdown()["data"])}
 
@@ -65,12 +65,12 @@ defmodule Mux.Data.RealTime do
   @doc """
   List histogram timeseries information for a specific metric
 
-  Returns `{:ok, histogram_timeseries, raw_env}`.
+  Returns `{:ok, raw_env | histogram_timeseries}`.
 
   ## Examples
 
       iex> client = Mux.client("my_token_id", "my_token_secret")
-      iex> {:ok, histogram_timeseries, _env} = Mux.Data.RealTime.histogram_timeseries(client, "video-startup-time", filters: ["operating_system:windows", "country:US"])
+      iex> {:ok, %{clean_body: histogram_timeseries} = _env} = Mux.Data.RealTime.histogram_timeseries(client, "video-startup-time", filters: ["operating_system:windows", "country:US"])
       iex> histogram_timeseries
       #{inspect(Fixtures.realtime_histogram_timeseries()["data"])}
 
@@ -82,12 +82,12 @@ defmodule Mux.Data.RealTime do
   @doc """
   List timeseries information for a specific metric along with the number of concurrent viewers.
 
-  Returns `{:ok, timeseries, raw_env}`.
+  Returns `{:ok, raw_env | timeseries}`.
 
   ## Examples
 
       iex> client = Mux.client("my_token_id", "my_token_secret")
-      iex> {:ok, timeseries, _env} = Mux.Data.RealTime.timeseries(client, "playback-failure-percentage", filters: ["operating_system:windows", "country:US"])
+      iex> {:ok, %{clean_body: timeseries} = _env} = Mux.Data.RealTime.timeseries(client, "playback-failure-percentage", filters: ["operating_system:windows", "country:US"])
       iex> timeseries
       #{inspect(Fixtures.realtime_timeseries()["data"])}
 

--- a/lib/mux/data/video_views.ex
+++ b/lib/mux/data/video_views.ex
@@ -11,17 +11,17 @@ defmodule Mux.Data.VideoViews do
   timeframe. Results are ordered by `view_end`, according to what you provide for
   `order_direction`.
 
-  Returns `{:ok, views, raw_env}`.
+  Returns `{:ok, raw_env | views}`.
 
   ## Examples
 
       iex> client = Mux.client("my_token_id", "my_token_secret")
-      iex> {:ok, views, _env} = Mux.Data.VideoViews.list(client)
+      iex> {:ok, %{clean_body: views} = _env} = Mux.Data.VideoViews.list(client)
       iex> views
       #{inspect(Fixtures.video_views()["data"])}
 
       iex> client = Mux.client("my_token_id", "my_token_secret")
-      iex> {:ok, views, _env} = Mux.Data.VideoViews.list(client, filters: ["browser:Chrome"], order_direction: "desc", page: 2)
+      iex> {:ok, %{clean_body: views} = _env} = Mux.Data.VideoViews.list(client, filters: ["browser:Chrome"], order_direction: "desc", page: 2)
       iex> views
       #{inspect(Fixtures.video_views()["data"])}
 
@@ -33,12 +33,12 @@ defmodule Mux.Data.VideoViews do
   @doc """
   Returns the details for a single video view.
 
-  Returns `{:ok, view, raw_env}`.
+  Returns `{:ok, raw_env | view}`.
 
   ## Examples
 
       iex> client = Mux.client("my_token_id", "my_token_secret")
-      iex> {:ok, view, _env} = Mux.Data.VideoViews.get(client, "k8n4aklUyrRDekILDWta1qSJqNFpYB7N50")
+      iex> {:ok, %{clean_body: view} = _env} = Mux.Data.VideoViews.get(client, "k8n4aklUyrRDekILDWta1qSJqNFpYB7N50")
       iex> view["id"] === "k8n4aklUyrRDekILDWta1qSJqNFpYB7N50"
       true
 

--- a/lib/mux/middleware/simplify_response.ex
+++ b/lib/mux/middleware/simplify_response.ex
@@ -3,12 +3,15 @@ defmodule Mux.Middleware.SimplifyResponse do
   @behaviour Tesla.Middleware
 
   def call(env, next, _options) do
-    with {:ok, resp} <- Tesla.run(env, next),
-         %{status: status} when status >= 200 and status < 300 <- resp do
-      {:ok, get_response_contents(resp.body), resp}
-    else
-      %{body: %{"error" => %{"type" => type, "messages" => messages}}} -> {:error, type, messages}
-      err -> raise Mux.Exception, err
+    case Tesla.run(env, next) do
+      {:ok, %{status: status} = resp} when status >= 200 and status < 300 ->
+        {:ok, resp |> Map.merge(%{clean_body: get_response_contents(resp.body)})}
+
+      {:ok, %{body: %{"error" => %{"type" => type, "messages" => messages}}} = resp} ->
+        {:error, resp |> Map.merge(%{error_type: type, error_messages: messages})}
+
+      err ->
+        raise Mux.Exception, err
     end
   end
 

--- a/lib/mux/video/assets.ex
+++ b/lib/mux/video/assets.ex
@@ -9,14 +9,14 @@ defmodule Mux.Video.Assets do
   @doc """
   Create a new asset.
 
-  Returns `{:ok, asset, %Tesla.Client{}}`.
+  Returns `{:ok, raw_env | asset}`.
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> Mux.Video.Assets.create(client, %{input: "https://example.com/video.mp4"})
-      {:ok, #{inspect(Fixtures.asset(:create))}, #{
-    inspect(Fixtures.tesla_env({:asset, [:create]}))
+      iex> {:ok, %{clean_body: asset} = _env} = Mux.Video.Assets.create(client, %{input: "https://example.com/video.mp4"})
+      iex> asset
+      #{inspect(Fixtures.asset(:create))}
   }}
 
   """
@@ -27,12 +27,12 @@ defmodule Mux.Video.Assets do
   @doc """
   List assets.
 
-  Returns a tuple such as `{:ok, assets, %Telsa.Env{}}`
+  Returns a tuple such as `{:ok, raw_env | assets}`
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {:ok, assets, _env} = Mux.Video.Assets.list(client)
+      iex> {:ok, %{clean_body: assets} = _env} = Mux.Video.Assets.list(client)
       iex> assets
       #{inspect([Fixtures.asset(), Fixtures.asset()])}
 
@@ -42,12 +42,12 @@ defmodule Mux.Video.Assets do
   @doc """
   Retrieve an asset by ID.
 
-  Returns a tuple such as `{:ok, asset, %Telsa.Env{}}`
+  Returns a tuple such as `{:ok, raw_env | asset}`
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {:ok, asset, _env} = Mux.Video.Assets.get(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc")
+      iex> {:ok, %{clean_body: asset} = _env} = Mux.Video.Assets.get(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc")
       iex> asset
       #{inspect(Fixtures.asset())}
 
@@ -59,12 +59,12 @@ defmodule Mux.Video.Assets do
   @doc """
   Delete an asset.
 
-  Returns a tuple such as `{:ok, %Telsa.Env{}}`
+  Returns a tuple such as `{:ok, raw_env}`
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {status, "", _env} = Mux.Video.Assets.delete(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc")
+      iex> {status, _env} = Mux.Video.Assets.delete(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc")
       iex> status
       :ok
 
@@ -76,12 +76,12 @@ defmodule Mux.Video.Assets do
   @doc """
   Retrieve the asset's input info.
 
-  Returns a tuple such as `{:ok, input_info, %Telsa.Env{}}`
+  Returns a tuple such as `{:ok, raw_env | input_info}`
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {:ok, input_info, _env} = Mux.Video.Assets.input_info(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc")
+      iex> {:ok, %{clean_body: input_info} = _env} = Mux.Video.Assets.input_info(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc")
       iex> input_info
       [#{inspect(Fixtures.input_info())}]
 
@@ -93,12 +93,12 @@ defmodule Mux.Video.Assets do
   @doc """
   Updates an asset's mp4 support
 
-  Returns a tuple such as `{:ok, asset, %Telsa.Env{}}`
+  Returns a tuple such as `{:ok, raw_env | asset}`
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {:ok, asset, _env} = Mux.Video.Assets.update_mp4_support(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", %{mp4_support: "standard"})
+      iex> {:ok, %{clean_body: asset} = _env} = Mux.Video.Assets.update_mp4_support(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", %{mp4_support: "standard"})
       iex> asset
       #{inspect(Fixtures.asset())}
 
@@ -110,12 +110,12 @@ defmodule Mux.Video.Assets do
   @doc """
   Updates an asset's master access
 
-  Returns a tuple such as `{:ok, asset, %Telsa.Env{}}`
+  Returns a tuple such as `{:ok, raw_env | asset}`
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {:ok, asset, _env} = Mux.Video.Assets.update_master_access(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", %{master_access: "temporary"})
+      iex> {:ok, %{clean_body: asset} = _env} = Mux.Video.Assets.update_master_access(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", %{master_access: "temporary"})
       iex> asset
       #{inspect(Fixtures.asset())}
 
@@ -127,14 +127,14 @@ defmodule Mux.Video.Assets do
   @doc """
   Create a new playback ID.
 
-  Returns `{:ok, playback_id, %Telsa.Env{}}`.
+  Returns `{:ok, raw_env | playback_id}`.
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {:ok, playback_id, _env} = Mux.Video.Assets.create_playback_id(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", %{policy: "public"})
+      iex> {:ok, %{clean_body: playback_id} = _env} = Mux.Video.Assets.create_playback_id(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", %{policy: "public"})
       iex> playback_id
-      #{inspect(Fixtures.playback_id)}
+      #{inspect(Fixtures.playback_id())}
 
   """
   def create_playback_id(client, asset_id, params) do
@@ -144,14 +144,14 @@ defmodule Mux.Video.Assets do
   @doc """
   Retrieve a playback ID.
 
-  Returns `{:ok, playback_id, %Telsa.Env{}}`.
+  Returns `{:ok, raw_env | playback_id}`.
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {:ok, playback_id, _env} = Mux.Video.Assets.get_playback_id(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", "FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE")
+      iex> {:ok, %{clean_body: playback_id} = _env} = Mux.Video.Assets.get_playback_id(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", "FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE")
       iex> playback_id
-      #{inspect(Fixtures.playback_id)}
+      #{inspect(Fixtures.playback_id())}
 
   """
   def get_playback_id(client, asset_id, playback_id) do
@@ -161,12 +161,12 @@ defmodule Mux.Video.Assets do
   @doc """
   Delete a playback ID.
 
-  Returns `{:ok, nil, %Telsa.Env{}}`.
+  Returns `{:ok, raw_env}`.
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {status, "", _env} = Mux.Video.Assets.delete_playback_id(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", "FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE")
+      iex> {status, _env} = Mux.Video.Assets.delete_playback_id(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", "FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE")
       iex> status
       :ok
 

--- a/lib/mux/video/delivery_usage.ex
+++ b/lib/mux/video/delivery_usage.ex
@@ -9,12 +9,12 @@ defmodule Mux.Video.DeliveryUsage do
   @doc """
   Get delivery usage for a specified timeframe. [API Documentation](https://docs.mux.com/reference#list-usage)
 
-  Returns `{:ok, delivery_usage, %Tesla.Env{}}`.
+  Returns `{:ok, raw_env | delivery_usage}}`.
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {:ok, delivery_usage, _env} = Mux.Video.DeliveryUsage.list(client, %{timeframe: [1564617600, 1569283200]})
+      iex> {:ok, %{clean_body: delivery_usage} = _env} = Mux.Video.DeliveryUsage.list(client, %{timeframe: [1564617600, 1569283200]})
       iex> delivery_usage
       #{inspect([Fixtures.delivery_usage(), Fixtures.delivery_usage()])}
   """

--- a/lib/mux/video/live_streams.ex
+++ b/lib/mux/video/live_streams.ex
@@ -9,12 +9,12 @@ defmodule Mux.Video.LiveStreams do
   @doc """
   Create a new live stream. [API Documentation](https://docs.mux.com/reference#create-a-live-stream)
 
-  Returns `{:ok, live_stream, %Tesla.Env{}}`.
+  Returns `{:ok, raw_env | live_stream}`.
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {:ok, live_stream, _env} = Mux.Video.LiveStreams.create(client, %{playback_policy: "public", new_asset_settings: %{playback_policy: "public"}})
+      iex> {:ok, %{clean_body: live_stream} = _env} = Mux.Video.LiveStreams.create(client, %{playback_policy: "public", new_asset_settings: %{playback_policy: "public"}})
       iex> live_stream
       #{inspect(Fixtures.live_stream())}
   """
@@ -25,12 +25,12 @@ defmodule Mux.Video.LiveStreams do
   @doc """
   List all live streams. [API Documentation](https://docs.mux.com/reference#list-live-streams)
 
-  Returns a tuple such as `{:ok, live_streams, %Tesla.Env{}}`
+  Returns a tuple such as `{:ok, raw_env | live_streams}`
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {:ok, live_streams, _env} = Mux.Video.LiveStreams.list(client)
+      iex> {:ok, %{clean_body: live_streams} = _env} = Mux.Video.LiveStreams.list(client)
       iex> live_streams
       #{inspect([Fixtures.live_stream(), Fixtures.live_stream()])}
 
@@ -40,12 +40,12 @@ defmodule Mux.Video.LiveStreams do
   @doc """
   Retrieve a live stream by ID. [API Documentation](https://docs.mux.com/reference#retrieve-a-live-stream)
 
-  Returns a tuple such as `{:ok, live_stream, %Tesla.Env{}}`
+  Returns a tuple such as `{:ok, raw_env | live_stream}`
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {:ok, live_stream, _env} = Mux.Video.LiveStreams.get(client, "aA02skpHXoLrbQm49qIzAG6RtewFOcDEY")
+      iex> {:ok, %{clean_body: live_stream} = _env} = Mux.Video.LiveStreams.get(client, "aA02skpHXoLrbQm49qIzAG6RtewFOcDEY")
       iex> live_stream
       #{inspect(Fixtures.live_stream())}
 
@@ -57,12 +57,12 @@ defmodule Mux.Video.LiveStreams do
   @doc """
   Delete a live stream. [API Documentation](https://docs.mux.com/reference#delete-a-live-stream)
 
-  Returns a tuple such as `{:ok, "", %Tesla.Env{}}`
+  Returns a tuple such as `{:ok, raw_env}`
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {status, _data, _env} = Mux.Video.LiveStreams.delete(client, "aA02skpHXoLrbQm49qIzAG6RtewFOcDEY")
+      iex> {status, _env} = Mux.Video.LiveStreams.delete(client, "aA02skpHXoLrbQm49qIzAG6RtewFOcDEY")
       iex> status
       :ok
 
@@ -74,12 +74,12 @@ defmodule Mux.Video.LiveStreams do
   @doc """
   Signal a live stream is finished. [API Documentation](https://docs.mux.com/reference#signal-live-stream-complete)
 
-  Returns a tuple such as `{:ok, "", %Tesla.Env{}}`
+  Returns a tuple such as `{:ok, "raw_env}`
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {status, _, _env} = Mux.Video.LiveStreams.signal_complete(client, "aA02skpHXoLrbQm49qIzAG6RtewFOcDEY")
+      iex> {status, _env} = Mux.Video.LiveStreams.signal_complete(client, "aA02skpHXoLrbQm49qIzAG6RtewFOcDEY")
       iex> status
       :ok
 
@@ -93,12 +93,12 @@ defmodule Mux.Video.LiveStreams do
   from working and create a new stream key that can be used for future broadcasts.
   [API Documentation](https://docs.mux.com/reference#reset-a-stream-key)
 
-  Returns a tuple such as `{:ok, "", %Tesla.Env{}}`
+  Returns a tuple such as `{:ok, raw_env}`
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {:ok, live_stream, _env} = Mux.Video.LiveStreams.reset_stream_key(client, "aA02skpHXoLrbQm49qIzAG6RtewFOcDEY")
+      iex> {:ok, %{clean_body: live_stream} = _env} = Mux.Video.LiveStreams.reset_stream_key(client, "aA02skpHXoLrbQm49qIzAG6RtewFOcDEY")
       iex> live_stream
       #{inspect(Fixtures.live_stream())}
 
@@ -110,12 +110,12 @@ defmodule Mux.Video.LiveStreams do
   @doc """
   Create a live stream playback ID. [API Documentation](https://docs.mux.com/reference#add-a-live-stream-playback-id)
 
-  Returns a tuple such as `{:ok, playback_ids, %Tesla.Env{}}`
+  Returns a tuple such as `{:ok, raw_env | playback_ids}`
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {:ok, playback_id, _env} = Mux.Video.LiveStreams.create_playback_id(client, "aA02skpHXoLrbQm49qIzAG6RtewFOcDEY", %{policy: "public"})
+      iex> {:ok, %{clean_body: playback_id} = _env} = Mux.Video.LiveStreams.create_playback_id(client, "aA02skpHXoLrbQm49qIzAG6RtewFOcDEY", %{policy: "public"})
       iex> playback_id
       #{inspect(Fixtures.playback_id())}
 
@@ -127,12 +127,12 @@ defmodule Mux.Video.LiveStreams do
   @doc """
   Delete a live stream playback ID. [API Documentation](https://docs.mux.com/reference#delete-a-live-stream-playback-id)
 
-  Returns a tuple such as `{:ok, "", %Tesla.Env{}}`
+  Returns a tuple such as `{:ok, raw_env}`
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {status, _, _env} = Mux.Video.LiveStreams.delete_playback_id(client, "aA02skpHXoLrbQm49qIzAG6RtewFOcDEY", "FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE")
+      iex> {status, _env} = Mux.Video.LiveStreams.delete_playback_id(client, "aA02skpHXoLrbQm49qIzAG6RtewFOcDEY", "FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE")
       iex> status
       :ok
 
@@ -144,12 +144,12 @@ defmodule Mux.Video.LiveStreams do
   @doc """
   Create a live stream simulcast target. [API Documentation](https://docs.mux.com/reference#create-a-simulcast-target)
 
-  Returns a tuple such as `{:ok, simulcast_target, %Tesla.Env{}}`
+  Returns a tuple such as `{:ok, raw_env | simulcast_target}`
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {:ok, simulcast_target, _env} = Mux.Video.LiveStreams.create_simulcast_target(client, "aA02skpHXoLrbQm49qIzAG6RtewFOcDEY", %{url: "rtmp://live.example.com/app", stream_key: "abcdefgh"})
+      iex> {:ok, %{clean_body: simulcast_target} = _env} = Mux.Video.LiveStreams.create_simulcast_target(client, "aA02skpHXoLrbQm49qIzAG6RtewFOcDEY", %{url: "rtmp://live.example.com/app", stream_key: "abcdefgh"})
       iex> simulcast_target
       #{inspect(Fixtures.simulcast_target())}
 
@@ -161,12 +161,12 @@ defmodule Mux.Video.LiveStreams do
   @doc """
   Retrieve a live stream simulcast target. [API Documentation](https://docs.mux.com/reference#retrieve-a-simulcast-target)
 
-  Returns a tuple such as `{:ok, simulcast_target, %Tesla.Env{}}`
+  Returns a tuple such as `{:ok, raw_env | simulcast_target}`
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {:ok, simulcast_target, _env} = Mux.Video.LiveStreams.get_simulcast_target(client, "aA02skpHXoLrbQm49qIzAG6RtewFOcDEY", "vuOfW021mz5QA500wYEQ9SeUYvuYnpFz011mqSvski5T8claN02JN9ve2g")
+      iex> {:ok, %{clean_body: simulcast_target} = _env} = Mux.Video.LiveStreams.get_simulcast_target(client, "aA02skpHXoLrbQm49qIzAG6RtewFOcDEY", "vuOfW021mz5QA500wYEQ9SeUYvuYnpFz011mqSvski5T8claN02JN9ve2g")
       iex> simulcast_target
       #{inspect(Fixtures.simulcast_target())}
 
@@ -178,12 +178,12 @@ defmodule Mux.Video.LiveStreams do
   @doc """
   Delete a live stream simulcast target. [API Documentation](https://docs.mux.com/reference#delete-a-simulcast-target)
 
-  Returns a tuple such as `{:ok, "", %Tesla.Env{}}`
+  Returns a tuple such as `{:ok, raw_env}`
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {status, _, _env} = Mux.Video.LiveStreams.delete_simulcast_target(client, "aA02skpHXoLrbQm49qIzAG6RtewFOcDEY", "vuOfW021mz5QA500wYEQ9SeUYvuYnpFz011mqSvski5T8claN02JN9ve2g")
+      iex> {status, _env} = Mux.Video.LiveStreams.delete_simulcast_target(client, "aA02skpHXoLrbQm49qIzAG6RtewFOcDEY", "vuOfW021mz5QA500wYEQ9SeUYvuYnpFz011mqSvski5T8claN02JN9ve2g")
       iex> status
       :ok
 
@@ -195,12 +195,12 @@ defmodule Mux.Video.LiveStreams do
   @doc """
   Enable a live stream is finished. [API Documentation](https://docs.mux.com/reference#enable-a-live-stream)
 
-  Returns a tuple such as `{:ok, "", %Tesla.Env{}}`
+  Returns a tuple such as `{:ok, raw_env}`
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {status, _, _env} = Mux.Video.LiveStreams.enable(client, "aA02skpHXoLrbQm49qIzAG6RtewFOcDEY")
+      iex> {status, _env} = Mux.Video.LiveStreams.enable(client, "aA02skpHXoLrbQm49qIzAG6RtewFOcDEY")
       iex> status
       :ok
 
@@ -212,12 +212,12 @@ defmodule Mux.Video.LiveStreams do
   @doc """
   Disable a live stream is finished. [API Documentation](https://docs.mux.com/reference#disable-a-live-stream)
 
-  Returns a tuple such as `{:ok, "", %Tesla.Env{}}`
+  Returns a tuple such as `{:ok, raw_env}`
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {status, _, _env} = Mux.Video.LiveStreams.disable(client, "aA02skpHXoLrbQm49qIzAG6RtewFOcDEY")
+      iex> {status, _env} = Mux.Video.LiveStreams.disable(client, "aA02skpHXoLrbQm49qIzAG6RtewFOcDEY")
       iex> status
       :ok
 

--- a/lib/mux/video/playback_ids.ex
+++ b/lib/mux/video/playback_ids.ex
@@ -11,12 +11,12 @@ defmodule Mux.Video.PlaybackIds do
   @doc """
   Retrieve a asset or live stream identifier by Playback ID.
 
-  Returns `{:ok, playback_id_full, raw_env}`.
+  Returns `{:ok, raw_env | playback_id_full}`.
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {:ok, playback_id_full, _env} = Mux.Video.PlaybackIds.get(client, "FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE")
+      iex> {:ok, %{clean_body: playback_id_full} = _env} = Mux.Video.PlaybackIds.get(client, "FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE")
       iex> playback_id_full
       #{inspect(Fixtures.playback_id_full())}
 

--- a/lib/mux/video/signing_keys.ex
+++ b/lib/mux/video/signing_keys.ex
@@ -10,14 +10,14 @@ defmodule Mux.Video.SigningKeys do
   @doc """
   Create a new signing key.
 
-  Returns `{:ok, signing_key, %Tesla.Client{}}`.
+  Returns `{:ok, %Tesla.Client{} | signing_key}`.
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> Mux.Video.SigningKeys.create(client)
-      {:ok, #{inspect(Fixtures.signing_key(:create))}, #{
-    inspect(Fixtures.tesla_env({:signing_key, [:create]}))
+      iex> {:ok, %{clean_body: keys} = _env} = Mux.Video.SigningKeys.create(client)
+      iex> keys
+      #{inspect(Fixtures.signing_key(:create))}
   }}
 
   """
@@ -28,12 +28,12 @@ defmodule Mux.Video.SigningKeys do
   @doc """
   List signing keys.
 
-  Returns a tuple such as `{:ok, signing_keys, %Telsa.Env{}}`
+  Returns a tuple such as `{:ok, %Telsa.Env{} | signing_key}`
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {:ok, signing_keys, _env} = Mux.Video.SigningKeys.list(client)
+      iex> {:ok, %{clean_body: signing_keys} = _env} = Mux.Video.SigningKeys.list(client)
       iex> signing_keys
       #{inspect([Fixtures.signing_key(), Fixtures.signing_key()])}
 
@@ -43,12 +43,12 @@ defmodule Mux.Video.SigningKeys do
   @doc """
   Retrieve a signing key by ID.
 
-  Returns a tuple such as `{:ok, signing_key, %Telsa.Env{}}`
+  Returns a tuple such as `{:ok, %Telsa.Env{} | signing_key}`
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {:ok, signing_key, _env} = Mux.Video.SigningKeys.get(client, "3kXq01SS00BQZqHHIq1egKAhuf7urAc400C")
+      iex> {:ok, %{clean_body: signing_key} = _env} = Mux.Video.SigningKeys.get(client, "3kXq01SS00BQZqHHIq1egKAhuf7urAc400C")
       iex> signing_key
       #{inspect(Fixtures.signing_key())}
 
@@ -65,7 +65,7 @@ defmodule Mux.Video.SigningKeys do
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {status, "", _env} = Mux.Video.SigningKeys.delete(client, "3kXq01SS00BQZqHHIq1egKAhuf7urAc400C")
+      iex> {status, %{clean_body: ""} = _env} = Mux.Video.SigningKeys.delete(client, "3kXq01SS00BQZqHHIq1egKAhuf7urAc400C")
       iex> status
       :ok
 

--- a/lib/mux/video/tracks.ex
+++ b/lib/mux/video/tracks.ex
@@ -8,12 +8,12 @@ defmodule Mux.Video.Tracks do
   @doc """
   Create a new asset track. [API Documentation](https://docs.mux.com/reference#create-a-subtitle-text-track)
 
-  Returns `{:ok, track, raw_env}`.
+  Returns `{:ok, raw_env | track}`.
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {:ok, track, _env} = Mux.Video.Tracks.create(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", %{url: "https://example.com/myVideo_en.srt", type: "text", text_type: "subtitles", language_code: "en" })
+      iex> {:ok, %{clean_body: track} = _env} = Mux.Video.Tracks.create(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", %{url: "https://example.com/myVideo_en.srt", type: "text", text_type: "subtitles", language_code: "en" })
       iex> track
       #{inspect(Fixtures.track())}
 
@@ -25,12 +25,12 @@ defmodule Mux.Video.Tracks do
   @doc """
   Delete an asset track. [API Documentation](https://docs.mux.com/reference#delete-a-subtitle-text-track)
 
-  Returns `{:ok, nil, raw_env}`.
+  Returns `{:ok, raw_env}`.
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {status, "", _env} = Mux.Video.Tracks.delete(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", "FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE")
+      iex> {status, %{clean_body: ""} = _env} = Mux.Video.Tracks.delete(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc", "FRDDXsjcNgD013rx1M4CDunZ86xkq8A02hfF3b6XAa7iE")
       iex> status
       :ok
 

--- a/lib/mux/video/uploads.ex
+++ b/lib/mux/video/uploads.ex
@@ -10,15 +10,15 @@ defmodule Mux.Video.Uploads do
   @doc """
   Create a new direct upload.
 
-  Returns `{:ok, upload, %Tesla.Client{}}`.
+  Returns `{:ok, %Tesla.Client{} | upload}`.
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
       iex> params = %{"new_asset_settings" => %{"playback_policies" => ["public"]}, "cors_origin" => "http://localhost:8080"}
-      iex> Mux.Video.Uploads.create(client, params)
-      {:ok, #{inspect(Fixtures.upload(:create))}, #{
-    inspect(Fixtures.tesla_env({:upload, [:create]}))
+      iex> {:ok, %{clean_body: upload} = _env} = Mux.Video.Uploads.create(client, params)
+      iex> upload
+      #{inspect(Fixtures.upload(:create))}
   }}
 
   """
@@ -29,12 +29,12 @@ defmodule Mux.Video.Uploads do
   @doc """
   List direct uploads.
 
-  Returns a tuple such as `{:ok, uploads, %Telsa.Env{}}`
+  Returns a tuple such as `{:ok, %Telsa.Env{} | uploads}`
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {:ok, uploads, _env} = Mux.Video.Uploads.list(client)
+      iex> {:ok, %{clean_body: uploads} = _env} = Mux.Video.Uploads.list(client)
       iex> uploads
       #{inspect([Fixtures.upload(), Fixtures.upload()])}
 
@@ -44,12 +44,12 @@ defmodule Mux.Video.Uploads do
   @doc """
   Retrieve a direct upload by ID.
 
-  Returns a tuple such as `{:ok, upload, %Telsa.Env{}}`
+  Returns a tuple such as `{:ok, %Telsa.Env{} | upload}`
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {:ok, upload, _env} = Mux.Video.Uploads.get(client, "OOTbA00CpWh6OgwV3asF00IvD2STk22UXM")
+      iex> {:ok, %{clean_body: upload} = _env} = Mux.Video.Uploads.get(client, "OOTbA00CpWh6OgwV3asF00IvD2STk22UXM")
       iex> upload
       #{inspect(Fixtures.upload())}
 
@@ -61,12 +61,12 @@ defmodule Mux.Video.Uploads do
   @doc """
   Cancel a direct upload.
 
-  Returns a tuple such as `{:ok, %Telsa.Env{}}`
+  Returns a tuple such as `{:ok, %Telsa.Env{} | direct_upload}`
 
   ## Examples
 
       iex> client = Mux.Base.new("my_token_id", "my_token_secret")
-      iex> {:ok, direct_upload, _env} = Mux.Video.Uploads.cancel(client, "OOTbA00CpWh6OgwV3asF00IvD2STk22UXM")
+      iex> {:ok, %{clean_body: direct_upload} = _env} = Mux.Video.Uploads.cancel(client, "OOTbA00CpWh6OgwV3asF00IvD2STk22UXM")
       iex> direct_upload
       #{inspect(Fixtures.upload(:cancel))}
 

--- a/test/mux/video/assets_test.exs
+++ b/test/mux/video/assets_test.exs
@@ -138,17 +138,17 @@ defmodule Mux.Video.AssetsTest do
     end
 
     test "returns a list of assets", %{client: client} do
-      {:ok, assets, _} = Assets.list(client)
+      {:ok, %{clean_body: assets}} = Assets.list(client)
       assert length(assets) == 2
     end
 
     test "takes query params as an option", %{client: client} do
-      {:ok, assets, _} = Assets.list(client, page: 2)
+      {:ok, %{clean_body: assets}} = Assets.list(client, page: 2)
       assert length(assets) == 1
     end
 
     test "returns a third argument that contains the raw Tesla.Env struct", %{client: client} do
-      assert {:ok, _, %Tesla.Env{}} = Assets.list(client)
+      assert {:ok, %Tesla.Env{}} = Assets.list(client)
     end
   end
 
@@ -168,7 +168,9 @@ defmodule Mux.Video.AssetsTest do
     end
 
     test "creates a new asset", %{client: client} do
-      {:ok, asset, %Tesla.Env{}} = Assets.create(client, %{input: "https://foobar.com/video.mp4"})
+      {:ok, %{clean_body: asset}} =
+        Assets.create(client, %{input: "https://foobar.com/video.mp4"})
+
       assert asset["status"] === "preparing"
     end
   end
@@ -189,7 +191,7 @@ defmodule Mux.Video.AssetsTest do
     end
 
     test "gets an asset by ID", %{client: client} do
-      assert {:ok, %{"id" => "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc"}, %Tesla.Env{}} =
+      assert {:ok, %{clean_body: %{"id" => "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc"}}} =
                Assets.get(client, "00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc")
     end
   end


### PR DESCRIPTION
This PR changes the `Mux.Middleware.SimplifyResponse` to comply with the expected shape of 2-element tuples. This PR closes #29.

Base idea is taken from https://github.com/teamon/tesla/issues/483#issuecomment-886727410

Please, feel free to change the name of the fields in the middleware!

If this gets merged, this might require a major version bump because it changes the expected API of the library.