### PR TITLE
Replace deprecated xor operator

### DIFF
--- a/lib/mux/webhooks.ex
+++ b/lib/mux/webhooks.ex
@@ -98,7 +98,7 @@ defmodule Mux.Webhooks do
     import Bitwise
 
     acc
-    |> bor(input_codepoint ^^^ expected_codepoint)
+    |> bor(bxor(input_codepoint, expected_codepoint))
     |> secure_compare(input, expected)
   end
 


### PR DESCRIPTION
The xor operator (`^^^/2`) has been [deprecated](https://hexdocs.pm/elixir/1.12/compatibility-and-deprecations.html#table-of-deprecations) in favor of `Bitwise.bxor/2` as of Elixir v1.12. Compiling the library currently emits the following warning:

```bash
^^^ is deprecated. It is typically used as xor but it has the wrong precedence, use Bitwise.bxor/2 instead
```