### PR TITLE
Swap out HTTP 201 statuses for HTTP 200 for mocked GET responses

### DIFF
--- a/test/mux/video/assets_test.exs
+++ b/test/mux/video/assets_test.exs
@@ -23,7 +23,7 @@ defmodule Mux.Video.AssetsTest do
 
       %{method: :get, url: @base_url <> "/video/v1/assets/00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc"} ->
         %Tesla.Env{
-          status: 201,
+          status: 200,
           body: %{
             "data" => Mux.Fixtures.asset()
           }
@@ -34,7 +34,7 @@ defmodule Mux.Video.AssetsTest do
         url: @base_url <> "/video/v1/assets/00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc/input-info"
       } ->
         %Tesla.Env{
-          status: 201,
+          status: 200,
           body: %{
             "data" => [Mux.Fixtures.input_info()]
           }
@@ -178,7 +178,7 @@ defmodule Mux.Video.AssetsTest do
       mock(fn
         %{method: :get, url: @base_url <> "/video/v1/assets/00ecNLnqiG8v00TLqqeZ00uCE5wCAaO3kKc"} ->
           %Tesla.Env{
-            status: 201,
+            status: 200,
             body: %{
               "data" => Mux.Fixtures.asset(:created)
             }

--- a/test/mux/video/live_streams_test.exs
+++ b/test/mux/video/live_streams_test.exs
@@ -84,7 +84,7 @@ defmodule Mux.Video.LiveStreamsTest do
               "/aA02skpHXoLrbQm49qIzAG6RtewFOcDEY/simulcast-targets/vuOfW021mz5QA500wYEQ9SeUYvuYnpFz011mqSvski5T8claN02JN9ve2g"
       } ->
         %Tesla.Env{
-          status: 201,
+          status: 200,
           body: %{
             "data" => Mux.Fixtures.simulcast_target()
           }


### PR DESCRIPTION
Some of the mocked HTTP responses return an HTTP 201 (created) status code for `GET` requests when 200 is the expected status code. Cross-referenced with API documentation to confirm.