### PR TITLE
Add real_time option to type_to_aud

### DIFF
--- a/lib/mux/token.ex
+++ b/lib/mux/token.ex
@@ -18,7 +18,7 @@ defmodule Mux.Token do
   `options` object can include:
   - `options.token_id`: Signing token ID (defaults to `Application.get_env(:mux, :signing_token_id)`)
   - `options.token_secret`: Signing token secret (defaults to `Application.get_env(:mux, :signing_token_secret)`)
-  - `options.type`: Type of signature to create. Defaults to `:video`, options are: `:video, :gif, :thumbnail, :storyboard`
+  - `options.type`: Type of signature to create. Defaults to `:video`, options are: `:video, :gif, :thumbnail, :storyboard, :real_time`
   - `options.expiration`: Seconds the token is valid for. Defaults to 7 days from now (604,800)
   - `options.params`: Map that includes any additional query params. For thumbnails this would be values like `height` or `time`.
   """
@@ -78,4 +78,5 @@ defmodule Mux.Token do
   defp type_to_aud(:thumbnail), do: "t"
   defp type_to_aud(:gif), do: "g"
   defp type_to_aud(:storyboard), do: "s"
+  defp type_to_aud(:real_time), do: "rt"
 end


### PR DESCRIPTION
This is currently missing from Mux.Token